### PR TITLE
Fix variable name typo

### DIFF
--- a/objects/obj_player/Create_0.gml
+++ b/objects/obj_player/Create_0.gml
@@ -5,7 +5,7 @@
 
 /* === movement tuning === */
 acceleration_x  = 1;
-decceleration_x = 1;
+deceleration_x = 1;
 max_velocity_x  = 5;
 
 fall_speed      = 1.2;

--- a/objects/obj_player/Step_0.gml
+++ b/objects/obj_player/Step_0.gml
@@ -46,7 +46,7 @@ if (dash_state == 0) {
     } else {  
         // no input or both left+right pressed – gradually decelerate to 0
         if (abs(velocity_x) > 1) {
-            velocity_x -= sign(velocity_x) * decceleration_x;
+            velocity_x -= sign(velocity_x) * deceleration_x;
         } else {
             velocity_x = 0;
         }


### PR DESCRIPTION
## Summary
- fix typo in movement variable

## Testing
- `echo "No tests"`

------
https://chatgpt.com/codex/tasks/task_e_6844d3dcaee48330994bb1e6bcb7a36d